### PR TITLE
fix: correct typo teh AE -> the AE

### DIFF
--- a/templates/papers/index.html
+++ b/templates/papers/index.html
@@ -90,7 +90,7 @@ div, iframe {
         </li>
         <li>
             <span id="j2cbadge" class="badge text-bg-primary" >
-                <a href="#" id="j2cbutton" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="TMLR J2C Paper">Journal to Conference</a></span> Awarded to publications based on responses by teh AE and reviewers, to the question of whether the work would be appropriate for the joint NeurIPS/ICLR/ICML Journal-to-Conference Track. Receiving this selective certification (or the Outstanding/Featured Certifications) enables an opportunity to present in this track at one of these participating conferences. See the <a href="https://neurips.cc/public/JournalToConference">track's website</a> for details and the complete list of eligibility criteria.
+                <a href="#" id="j2cbutton" data-bs-toggle="tooltip" data-bs-placement="top" data-bs-title="TMLR J2C Paper">Journal to Conference</a></span> Awarded to publications based on responses by the AE and reviewers, to the question of whether the work would be appropriate for the joint NeurIPS/ICLR/ICML Journal-to-Conference Track. Receiving this selective certification (or the Outstanding/Featured Certifications) enables an opportunity to present in this track at one of these participating conferences. See the <a href="https://neurips.cc/public/JournalToConference">track's website</a> for details and the complete list of eligibility criteria.
         </li>
         <li>
             <span id="eventbadge" class="badge text-bg-light" >


### PR DESCRIPTION
Fixed: teh AE -> the AE

Closes #11